### PR TITLE
Add missing reference to Figure 1

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -3,7 +3,7 @@
 import os
 import sys
 # sys.path.insert(0, os.path.abspath('.'))
-
+numfig = True
 # -- General configuration ------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be

--- a/flamegpu/introduction.rst
+++ b/flamegpu/introduction.rst
@@ -54,7 +54,7 @@ the lifecycle of a single iteration. This allows a mechanism for agents
 to iteratively interact in a way which allows emergent global group
 behaviour.
 
-The process of generating a FLAME GPU simulation is described by the 1.
+The process of generating a FLAME GPU simulation is described by :numref:`figure1-label`.
 The use of XML schemas forms a large part of the process where
 polymorphic like extension allows a base schema specification to be
 extended with a number of GPU specific elements. Given an XMML model
@@ -69,6 +69,7 @@ which links with the *Agent Function Files* to generate a simulation
 program.
 
 .. figure:: /images/figure1.jpg
+   :name: figure1-label
    :alt: FLAME GPU Modelling and Simulation Processes
    :width: 100.0%
 


### PR DESCRIPTION
As I understand, 'the 1' should be replaced by a reference to Figure 1. Perhaps the numerical reference was meant to be replaced automatically by the parser or by an additional script? Anyway, the proposed solution only requires adding a parameter to the config and a name to the image.